### PR TITLE
Km/return http status codes

### DIFF
--- a/album.go
+++ b/album.go
@@ -39,19 +39,20 @@ type AlbumInfo struct {
 	Limit       *RateLimit  // Current rate limit
 }
 
-// GetAlbumInfo queries imgur for information on a album
-// returns album info, status code of the request, error
+// GetAlbumInfo queries imgur for information on an album
+// returns album info, status code of the request or of album payload, error
+// http status code of request, -1 if request was not made
 func (client *Client) GetAlbumInfo(id string) (*AlbumInfo, int, error) {
-	body, rl, err := client.getURL("album/" + id)
+	body, statusCode, rl, err := client.getURL("album/" + id)
 	if err != nil {
-		return nil, -1, errors.New("Problem getting URL for album info ID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem getting URL for album info ID " + id + " - " + err.Error())
 	}
 	//client.Log.Debugf("%v\n", body)
 
 	dec := json.NewDecoder(strings.NewReader(body))
 	var alb albumInfoDataWrapper
 	if err := dec.Decode(&alb); err != nil {
-		return nil, -1, errors.New("Problem decoding json for albumID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem decoding json for albumID " + id + " - " + err.Error())
 	}
 
 	if !alb.Success {

--- a/album.go
+++ b/album.go
@@ -47,8 +47,6 @@ func (client *Client) GetAlbumInfo(id string) (*AlbumInfo, int, error) {
 	if err != nil {
 		return nil, statusCode, errors.New("Problem getting URL for album info ID " + id + " - " + err.Error())
 	}
-	//client.Log.Debugf("%v\n", body)
-
 	dec := json.NewDecoder(strings.NewReader(body))
 	var alb albumInfoDataWrapper
 	if err := dec.Decode(&alb); err != nil {

--- a/fromURL.go
+++ b/fromURL.go
@@ -128,7 +128,7 @@ func (client *Client) imageURL(url string) (*GenericInfo, int, error) {
 	ii, status, err := client.GetGalleryImageInfo(id)
 	if err == nil && status < 400 {
 		ret.GImage = ii
-		return &ret, status, err
+		return &ret, status, fmt.Errorf("client.GetGalleryImageInfo:%w", err)
 	}
 
 	i, statusCode, err := client.GetImageInfo(id)

--- a/fromURL.go
+++ b/fromURL.go
@@ -17,7 +17,7 @@ type GenericInfo struct {
 }
 
 // GetInfoFromURL tries to query imgur based on information identified in the URL.
-// returns image/album info, status code of the request, error
+// returns image/album info, http status code of the request, error
 func (client *Client) GetInfoFromURL(url string) (*GenericInfo, int, error) {
 	url = strings.TrimSpace(url)
 

--- a/fromURL.go
+++ b/fromURL.go
@@ -128,7 +128,7 @@ func (client *Client) imageURL(url string) (*GenericInfo, int, error) {
 	ii, status, err := client.GetGalleryImageInfo(id)
 	if err == nil && status < 400 {
 		ret.GImage = ii
-		return &ret, status, fmt.Errorf("client.GetGalleryImageInfo:%w", err)
+		return &ret, status, nil
 	}
 
 	i, statusCode, err := client.GetImageInfo(id)

--- a/fromURL.go
+++ b/fromURL.go
@@ -2,6 +2,7 @@ package imgur
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -118,7 +119,7 @@ func (client *Client) imageURL(url string) (*GenericInfo, int, error) {
 	if id == "" {
 		return nil, -1, errors.New("Could not find ID in URL " + url + ". I was going down imgur.com/ path.")
 	}
-	// check if id is a full filename E.G vsadghes.jpg, and if so, extract the actual id
+	// check if id is a full filename E.G `vsadghes.jpg`, and if so, extract the actual id `vsadghes`
 	hasDotIndex := strings.LastIndex(id, ".")
 	if hasDotIndex > -1 {
 		id = id[0:hasDotIndex]
@@ -127,11 +128,13 @@ func (client *Client) imageURL(url string) (*GenericInfo, int, error) {
 	ii, status, err := client.GetGalleryImageInfo(id)
 	if err == nil && status < 400 {
 		ret.GImage = ii
-
 		return &ret, status, err
 	}
 
-	i, st, err := client.GetImageInfo(id)
+	i, statusCode, err := client.GetImageInfo(id)
+	if err != nil {
+		return nil, statusCode, fmt.Errorf("client.GetImageInfo:%w", err)
+	}
 	ret.Image = i
-	return &ret, st, err
+	return &ret, statusCode, nil
 }

--- a/fromURL_test.go
+++ b/fromURL_test.go
@@ -268,7 +268,7 @@ func TestGetURLImageSimulated(t *testing.T) {
 	g.Expect(ge.GAlbum).To(BeNil())
 
 	g.Expect(ge.Image).NotTo(BeNil())
-	// the mock response is for an Image, not a GalleryImage, so Image will be nil
+	// the mock response is for an Image, not a GalleryImage, so GImage will be nil
 	g.Expect(ge.GImage).To(BeNil())
 
 	img := ge.Image
@@ -313,7 +313,7 @@ func TestGetURLImageSimulatedWithExtension(t *testing.T) {
 	g.Expect(ge.GAlbum).To(BeNil())
 
 	g.Expect(ge.Image).NotTo(BeNil())
-	// the mock response is for an Image, not a GalleryImage, so Image will be nil
+	// the mock response is for an Image, not a GalleryImage, so GImage will be nil
 	g.Expect(ge.GImage).To(BeNil())
 
 	img := ge.Image
@@ -381,7 +381,7 @@ func TestGetURLImageSimulatedWithExtensionMoved302(t *testing.T) {
 	g.Expect(info["GET https://api.imgur.com/3/image/moved_url"]).To(Equal(1))
 
 	g.Expect(ge.Image).NotTo(BeNil())
-	// the mock response is for an Image, not a GalleryImage, so Image will be nil
+	// the mock response is for an Image, not a GalleryImage, so GImage will be nil
 	g.Expect(ge.GImage).To(BeNil())
 
 	img := ge.Image

--- a/fromURL_test.go
+++ b/fromURL_test.go
@@ -1,7 +1,6 @@
 package imgur
 
 import (
-	"fmt"
 	"github.com/jarcoal/httpmock"
 	"net/http"
 	"os"
@@ -371,7 +370,6 @@ func TestGetURLImageSimulatedWithExtensionMoved302(t *testing.T) {
 	MockStringResp("https://api.imgur.com/3/image/moved_url", http.MethodGet, responseString, nil)
 
 	ge, status, err := client.GetInfoFromURL("https://imgur.com/ClF8rLe.jpg")
-	fmt.Printf("%v \n", err)
 	g.Expect(ge).NotTo(BeNil())
 	g.Expect(err).To(BeNil())
 	g.Expect(status).To(Equal(200))

--- a/galleryAlbum.go
+++ b/galleryAlbum.go
@@ -48,16 +48,16 @@ type GalleryAlbumInfo struct {
 // GetGalleryAlbumInfo queries imgur for information on a gallery album
 // returns album info, status code of the request, error
 func (client *Client) GetGalleryAlbumInfo(id string) (*GalleryAlbumInfo, int, error) {
-	body, rl, err := client.getURL("gallery/album/" + id)
+	body, statusCode, rl, err := client.getURL("gallery/album/" + id)
 	if err != nil {
-		return nil, -1, errors.New("Problem getting URL for gallery album info ID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem getting URL for gallery album info ID " + id + " - " + err.Error())
 	}
 	// client.Log.Debugf("%v\n", body)
 
 	dec := json.NewDecoder(strings.NewReader(body))
 	var alb galleryAlbumInfoDataWrapper
 	if err := dec.Decode(&alb); err != nil {
-		return nil, -1, errors.New("Problem decoding json for gallery albumID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem decoding json for gallery albumID " + id + " - " + err.Error())
 	}
 	alb.Ai.Limit = rl
 

--- a/galleryImage.go
+++ b/galleryImage.go
@@ -53,16 +53,16 @@ type GalleryImageInfo struct {
 // GetGalleryImageInfo queries imgur for information on a image
 // returns image info, status code of the request, error
 func (client *Client) GetGalleryImageInfo(id string) (*GalleryImageInfo, int, error) {
-	body, rl, err := client.getURL("gallery/image/" + id)
+	body, statusCode, rl, err := client.getURL("gallery/image/" + id)
 	if err != nil {
-		return nil, -1, errors.New("Problem getting URL for gallery image info ID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem getting URL for gallery image info ID " + id + " - " + err.Error())
 	}
 	// client.Log.Debugf("%v\n", body)
 
 	dec := json.NewDecoder(strings.NewReader(body))
 	var img galleryImageInfoDataWrapper
 	if err := dec.Decode(&img); err != nil {
-		return nil, -1, errors.New("Problem decoding json for gallery imageID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem decoding json for gallery imageID " + id + " - " + err.Error())
 	}
 	img.Ii.Limit = rl
 

--- a/image.go
+++ b/image.go
@@ -42,17 +42,17 @@ type ImageInfo struct {
 }
 
 // GetImageInfo queries imgur for information on a image
-// returns image info, status code of the request, error
+// returns image info, http status code of the request, error
 func (client *Client) GetImageInfo(id string) (*ImageInfo, int, error) {
-	body, rl, err := client.getURL("image/" + id)
+	body, statusCode, rl, err := client.getURL("image/" + id)
 	if err != nil {
-		return nil, -1, errors.New("Problem getting URL for image info ID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem getting URL for image info ID " + id + " - " + err.Error())
 	}
 
 	dec := json.NewDecoder(strings.NewReader(body))
 	var img imageInfoDataWrapper
 	if err := dec.Decode(&img); err != nil {
-		return nil, -1, errors.New("Problem decoding json for imageID " + id + " - " + err.Error())
+		return nil, statusCode, errors.New("Problem decoding json for imageID " + id + " - " + err.Error())
 	}
 	img.Ii.Limit = rl
 

--- a/rateLimit.go
+++ b/rateLimit.go
@@ -76,7 +76,7 @@ func extractRateLimits(h http.Header) (rl *RateLimit, err error) {
 // GetRateLimit returns the current rate limit without doing anything else
 func (client *Client) GetRateLimit() (*RateLimit, error) {
 	// We are requesting any URL and parse the returned HTTP headers
-	body, rl, err := client.getURL("account/kaffeeshare")
+	body, _, rl, err := client.getURL("account/kaffeeshare")
 
 	if err != nil {
 		return nil, errors.New("Problem getting URL for rate - " + err.Error())


### PR DESCRIPTION
Fix so that client.GetInfoFromURL will return proper http status codes and we don't have to string match

